### PR TITLE
Add an automatic Github pages publish step for the action.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,13 +25,13 @@ inputs:
   github_token:
     description: >-
       The Github token used to deploy the Github pages — Github already generates this in
-             the workflow parameter "secrets.GITHUB_TOKEN".
+      the workflow parameter "secrets.GITHUB_TOKEN".
     required: false
   main_ref:
     description: >-
       The main branch where a push will trigger the Github Pages build. This is of the form
-             "refs/heads/main", with the branch name substituted for the last item in the path. Note that
-             there is no leading slash.
+      "refs/heads/main", with the branch name substituted for the last item in the path. Note that
+      there is no leading slash.
     required: false
   scribble_file:
     description: >-

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,26 @@ inputs:
       ".", is intended to be used with single-package repositories.
     required: false
     default: .
+  doc_directory:
+    description: >-
+      The documentation directory to look for scribble docs, relative to the root of the
+      repository.
+    required: false
+  github_token:
+    description: >-
+      The Github token used to deploy the Github pages — Github already generates this in
+             the workflow parameter "secrets.GITHUB_TOKEN".
+    required: false
+  main_ref:
+    description: >-
+      The main branch where a push will trigger the Github Pages build. This is of the form
+             "refs/heads/main", with the branch name substituted for the last item in the path. Note that
+             there is no leading slash.
+    required: false
+  scribble_file:
+    description: >-
+      The scribble file to use as an entry-point into the script, without the .scribl extension.
+    required: false
 runs:
   using: docker
   image: Dockerfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,6 @@ if [ -n "$INPUT_DOC_DIRECTORY" ] && [ -n "$INPUT_SCRIBBLE_FILE" ] \
        && [ -n "$INPUT_MAIN_REF" ] && [ -n "$INPUT_GITHUB_TOKEN" ]; then
     if [[ -z "$GITHUB_BASE_REF" ]] && [ "$INPUT_MAIN_REF" == "$GITHUB_REF" ]; then
         echo "Uploading documentation under ${INPUT_DOC_DIRECTORY}..."
-	ls -alt
 	raco scribble +m --htmls \
 	     --redirect-main http://pkg-build.racket-lang.org/doc/ \
 	     --dest ./docs \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,3 +30,33 @@ fi
 # locally. In those cases, prefer counting the stderr output as a legitimate
 # failure and switch to using `raco test --drdr` locally.
 raco test --package --drdr "$INPUT_NAME"
+
+# This part of the script, which publishes the scribble docs to Github pages,
+# is adapted from Alexis King’s original scripts for Travis CI. Unfortunately,
+# we cannot infer very much from the package structure so we rely on the
+# the user to set the paths.
+if [ -n "$INPUT_DOC_DIRECTORY" ] && [ -n "$INPUT_SCRIBBLE_FILE" ] \
+       && [ -n "$INPUT_MAIN_REF" ] && [ -n "$INPUT_GITHUB_TOKEN" ]; then
+    if [[ -z "$GITHUB_BASE_REF" ]] && [ "$INPUT_MAIN_REF" == "$GITHUB_REF" ]; then
+        echo "Uploading documentation under ${INPUT_DOC_DIRECTORY}..."
+	ls -alt
+	raco scribble +m --htmls \
+	     --redirect-main http://pkg-build.racket-lang.org/doc/ \
+	     --dest ./docs \
+	     "${INPUT_DOC_DIRECTORY}/scribblings/${INPUT_SCRIBBLE_FILE}.scribl"
+	# Here we create a /new/ repository with no history where the scribble docs are generated.
+	cd docs || exit 1
+	# Sometimes the scribble command will create a subfolder, but Github doesn't like it.
+	# This is a noop in the case that there isn't one.
+	cd $(find . -maxdepth 1 -type d | tail -n1) || exit 1
+        git config --global user.email $(git show -s --format=format:%ae) 
+        git config --global user.name $(git show -s --format=formmat:%an)
+	git init
+	git add .
+	git commit -m 'Deploy to Github Pages'
+	# Rarely do we want to actually save the history of the Github Pages — force pushing wipes the history.
+	git push --force  \
+	    "https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+	    master:gh-pages
+    fi
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,7 +50,7 @@ if [ -n "$INPUT_DOC_DIRECTORY" ] && [ -n "$INPUT_SCRIBBLE_FILE" ] \
 	# This is a noop in the case that there isn't one.
 	cd $(find . -maxdepth 1 -type d | tail -n1) || exit 1
         git config --global user.email $(git show -s --format=format:%ae) 
-        git config --global user.name $(git show -s --format=formmat:%an)
+        git config --global user.name $(git show -s --format=format:%an)
 	git init
 	git add .
 	git commit -m 'Deploy to Github Pages'


### PR DESCRIPTION
Hi,

This adds an automatic publish step for the action since it's quite common to do - it works, insofar as it pushes the HTML into the correct branch et. cetera. Many thanks to @lexi-lambda for the original Travis CI script which I basically copied.

There is a slight problem with it so far - the links don't seem to point to the right location - what was the reason for the local linking?